### PR TITLE
support for Unbuntu 14.04LTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ all: install_node install_boost install_userspacercu install_hiredis install_sna
 
 .PHONY: install_node install_boost install_userspacercu install_hiredis install_snappy install_cityhash install_zeromq install_libssh2 install_libcurl install_curlpp install_protobuf install_gperftools install_zookeeper install_redis install_mongodb_cxx_driver install_jq
 
+ubuntu_14.04_repos:
+	git submodule update --init cityhash node mongo-cxx-driver userspace-rcu
+
+ubuntu_14.04_deps: install_node install_cityhash install_mongodb_cxx_driver install_userspacercu
+
 install_node:
 	JOBS=$(JOBS) cd node && ./recoset_build_node.sh
 


### PR DESCRIPTION
This commit adds support for Ubuntu 14.04 LTS
Two new GNUmake targets:
- unbuntu_14.04_repos: update submodules to be used (cityhash node mongo-cxx-driver userspace-rcu)
- ubuntu_14.04_deps: makes platform dependencies above. 
